### PR TITLE
Add Clear Grid button to crafting GUI

### DIFF
--- a/common/src/main/java/io/github/scuba10steve/s3/gui/client/StorageCoreCraftingScreen.java
+++ b/common/src/main/java/io/github/scuba10steve/s3/gui/client/StorageCoreCraftingScreen.java
@@ -1,7 +1,10 @@
 package io.github.scuba10steve.s3.gui.client;
 
 import io.github.scuba10steve.s3.gui.server.StorageCoreCraftingMenu;
+import io.github.scuba10steve.s3.network.ClearCraftingGridPacket;
+import io.github.scuba10steve.s3.platform.S3Platform;
 import io.github.scuba10steve.s3.ref.RefStrings;
+import net.minecraft.client.gui.components.Button;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Inventory;
@@ -24,5 +27,18 @@ public class StorageCoreCraftingScreen extends AbstractStorageScreen<StorageCore
         this.storageAreaHeight = 72; // 4 rows * 18px
 
         LOGGER.debug("StorageCoreCraftingScreen created");
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+
+        Button clearButton = Button.builder(
+                Component.translatable("gui.s3.clear"),
+                btn -> S3Platform.getNetworkHelper().sendToServer(new ClearCraftingGridPacket(menu.getPos()))
+            )
+            .bounds(this.leftPos + 108, this.topPos + 137, 30, 12)
+            .build();
+        this.addRenderableWidget(clearButton);
     }
 }

--- a/common/src/main/java/io/github/scuba10steve/s3/gui/server/StorageCoreCraftingMenu.java
+++ b/common/src/main/java/io/github/scuba10steve/s3/gui/server/StorageCoreCraftingMenu.java
@@ -344,6 +344,11 @@ public class StorageCoreCraftingMenu extends StorageCoreMenu {
         return ItemStack.EMPTY;
     }
 
+    public void handleClearGrid(Player player) {
+        clearGrid(player);
+        updateCraftingResult();
+    }
+
     private void clearGrid(Player playerIn) {
         for (int i = 0; i < 9; i++) {
             ItemStack stack = this.craftMatrix.getItem(i);

--- a/common/src/main/java/io/github/scuba10steve/s3/network/ClearCraftingGridPacket.java
+++ b/common/src/main/java/io/github/scuba10steve/s3/network/ClearCraftingGridPacket.java
@@ -1,0 +1,29 @@
+package io.github.scuba10steve.s3.network;
+
+import io.github.scuba10steve.s3.ref.RefStrings;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+/**
+ * Packet sent from client to server to clear the crafting grid,
+ * returning items to storage.
+ */
+public record ClearCraftingGridPacket(BlockPos pos) implements CustomPacketPayload {
+
+    public static final CustomPacketPayload.Type<ClearCraftingGridPacket> TYPE =
+        new CustomPacketPayload.Type<>(ResourceLocation.fromNamespaceAndPath(RefStrings.MODID, "clear_crafting_grid"));
+
+    public static final StreamCodec<FriendlyByteBuf, ClearCraftingGridPacket> STREAM_CODEC = StreamCodec.of(
+        (buf, packet) -> buf.writeBlockPos(packet.pos),
+        buf -> new ClearCraftingGridPacket(buf.readBlockPos())
+    );
+
+    @Override
+    public Type<? extends CustomPacketPayload> type() {
+        return TYPE;
+    }
+
+}

--- a/common/src/main/resources/assets/s3/lang/en_us.json
+++ b/common/src/main/resources/assets/s3/lang/en_us.json
@@ -27,5 +27,6 @@
   "item.s3.dolly": "Dolly",
   "item.s3.dolly_super": "Super Dolly",
 
-  "gui.s3.search": "Search..."
+  "gui.s3.search": "Search...",
+  "gui.s3.clear": "Clear"
 }

--- a/neoforge/src/main/java/io/github/scuba10steve/s3/network/ModNetwork.java
+++ b/neoforge/src/main/java/io/github/scuba10steve/s3/network/ModNetwork.java
@@ -44,6 +44,12 @@ public class ModNetwork {
         );
 
         registrar.playToServer(
+            ClearCraftingGridPacket.TYPE,
+            ClearCraftingGridPacket.STREAM_CODEC,
+            PacketHandlers::handleClearCraftingGrid
+        );
+
+        registrar.playToServer(
             RecipeTransferPacket.TYPE,
             RecipeTransferPacket.STREAM_CODEC,
             PacketHandlers::handleRecipeTransfer


### PR DESCRIPTION
## Summary
- Adds a "Clear" button to the Storage Core crafting screen that returns all 3x3 grid items back to connected storage on demand
- Reuses the existing `clearGrid()` logic (previously only triggered on menu close) via a new `handleClearGrid()` public method
- Follows established packet/handler patterns (`SortModePacket`, `handleRecipeTransfer`)

## Test plan
- [ ] Open crafting GUI, place items in grid, click "Clear" — items return to storage and result slot clears
- [ ] Click "Clear" with no storage connected — items drop to player inventory/ground
- [ ] Click "Clear" on an empty grid — nothing happens
- [ ] Verify button doesn't overlap other UI elements
- [ ] `./gradlew :neoforge:build` compiles cleanly
- [ ] `./gradlew :common:test` all unit tests pass

Closes #22