### PR TITLE
Add Nexus Mods publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,3 +95,13 @@ jobs:
           changelog: ${{ steps.changelog.outputs.content }}
           dependencies: |
             jei@19.27.0.336(optional){curseforge:238222}
+
+      - name: Publish to Nexus Mods
+        uses: Nexus-Mods/upload-action@main
+        with:
+          api_key: ${{ secrets.NEXUSMODS_API_KEY }}
+          file_id: ${{ vars.NEXUSMODS_FILE_ID }}
+          game_domain_name: minecraft
+          filename: neoforge/build/libs/s3-${{ steps.version.outputs.version }}.jar
+          version: ${{ steps.version.outputs.version }}
+          display_name: Steve's Simple Storage v${{ steps.version.outputs.version }}


### PR DESCRIPTION
## Summary
- Adds a new publish step to the release workflow using the official `Nexus-Mods/upload-action`
- Publishes the mod JAR to Nexus Mods alongside existing CurseForge and Modrinth targets

## Prerequisites (before merging)
- [x] Create mod page on nexusmods.com/minecraft
- [x] Upload initial JAR manually to get a `file_id`
- [x] Add repo secret: `NEXUSMODS_API_KEY`
- [x] Add repo variable: `NEXUSMODS_FILE_ID`

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Configure secrets/variables in repo settings
- [ ] Trigger a manual workflow dispatch and confirm file appears on Nexus Mods

Closes #33