### PR TITLE
Add release type input to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,14 @@ on:
         description: 'Release version (defaults to mod_version from gradle.properties)'
         required: false
         type: string
+      release_type:
+        description: 'Release type'
+        required: true
+        type: choice
+        default: beta
+        options:
+          - beta
+          - release
 
 permissions:
   contents: write
@@ -63,6 +71,7 @@ jobs:
           name: v${{ steps.version.outputs.version }}
           body: ${{ steps.changelog.outputs.content }}
           files: neoforge/build/libs/s3-${{ steps.version.outputs.version }}.jar
+          prerelease: ${{ inputs.release_type == 'beta' }}
 
       - name: Publish to Modrinth
         uses: Kir-Antipov/mc-publish@v3.3
@@ -72,7 +81,7 @@ jobs:
           files: neoforge/build/libs/s3-${{ steps.version.outputs.version }}.jar
           name: Steve's Simple Storage v${{ steps.version.outputs.version }}
           version: ${{ steps.version.outputs.version }}
-          version-type: beta
+          version-type: ${{ inputs.release_type }}
           loaders: neoforge
           game-versions: 1.21.1
           java: 21
@@ -88,7 +97,7 @@ jobs:
           files: neoforge/build/libs/s3-${{ steps.version.outputs.version }}.jar
           name: Steve's Simple Storage v${{ steps.version.outputs.version }}
           version: ${{ steps.version.outputs.version }}
-          version-type: beta
+          version-type: ${{ inputs.release_type }}
           loaders: neoforge
           game-versions: 1.21.1
           java: 21


### PR DESCRIPTION
## Summary

- Add `release_type` workflow dispatch input with `beta` (default) and `release` choices
- Pass selected type to CurseForge and Modrinth `version-type` fields
- Set GitHub Release `prerelease: true` when type is `beta`

Closes #30

## Test plan

- [x] Trigger workflow dispatch UI shows the new dropdown with beta/release options
- [ ] Beta release: GitHub release marked as pre-release, CurseForge/Modrinth get `version-type: beta`
- [ ] Full release: GitHub release is a full release, CurseForge/Modrinth get `version-type: release`