### PR TITLE
Truncate large item counts with K/M/B suffixes

### DIFF
--- a/core/src/main/java/io/github/scuba10steve/s3/gui/client/AbstractStorageScreen.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/gui/client/AbstractStorageScreen.java
@@ -6,6 +6,7 @@ import io.github.scuba10steve.s3.network.SortModePacket;
 import io.github.scuba10steve.s3.network.StorageClickPacket;
 import io.github.scuba10steve.s3.storage.StorageInventory;
 import io.github.scuba10steve.s3.storage.StoredItemStack;
+import io.github.scuba10steve.s3.util.CountFormatter;
 import io.github.scuba10steve.s3.util.SortMode;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -19,7 +20,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.TooltipFlag;
 
-import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -268,10 +268,7 @@ public abstract class AbstractStorageScreen<T extends StorageCoreMenu> extends A
 
         // Render item count
         if (inventory != null) {
-            DecimalFormat formatter = new DecimalFormat("#,###");
-            String totalCount = formatter.format(inventory.getTotalItemCount());
-            String max = formatter.format(inventory.getMaxItems());
-            String amount = totalCount + "/" + max;
+            String amount = formatCount(inventory.getTotalItemCount()) + "/" + formatCount(inventory.getMaxItems());
             int stringWidth = font.width(amount);
             guiGraphics.drawString(font, amount, 187 - stringWidth, 6, 0x404040, false);
         }
@@ -368,10 +365,7 @@ public abstract class AbstractStorageScreen<T extends StorageCoreMenu> extends A
     }
 
     protected String formatCount(long count) {
-        if (count < 1000) return String.valueOf(count);
-        if (count < 1000000) return (count / 1000) + "K";
-        if (count < 1000000000) return (count / 1000000) + "M";
-        return (count / 1000000000) + "B";
+        return CountFormatter.formatCount(count);
     }
 
     @Override

--- a/core/src/main/java/io/github/scuba10steve/s3/util/CountFormatter.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/util/CountFormatter.java
@@ -1,0 +1,23 @@
+package io.github.scuba10steve.s3.util;
+
+public final class CountFormatter {
+
+    private CountFormatter() {}
+
+    public static String formatCount(long count) {
+        if (count < 1000) return String.valueOf(count);
+        if (count < 10_000) return formatWithSuffix(count, 1000, "K");
+        if (count < 1_000_000) return (count / 1000) + "K";
+        if (count < 10_000_000) return formatWithSuffix(count, 1_000_000, "M");
+        if (count < 1_000_000_000) return (count / 1_000_000) + "M";
+        if (count < 10_000_000_000L) return formatWithSuffix(count, 1_000_000_000, "B");
+        return (count / 1_000_000_000) + "B";
+    }
+
+    private static String formatWithSuffix(long count, long divisor, String suffix) {
+        long whole = count / divisor;
+        long fraction = (count % divisor) * 10 / divisor;
+        if (fraction == 0) return whole + suffix;
+        return whole + "." + fraction + suffix;
+    }
+}

--- a/core/src/test/java/io/github/scuba10steve/s3/gui/FormatCountTest.java
+++ b/core/src/test/java/io/github/scuba10steve/s3/gui/FormatCountTest.java
@@ -1,0 +1,53 @@
+package io.github.scuba10steve.s3.gui;
+
+import io.github.scuba10steve.s3.util.CountFormatter;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FormatCountTest {
+
+    @Test
+    void testSmallValues() {
+        assertEquals("0", CountFormatter.formatCount(0));
+        assertEquals("1", CountFormatter.formatCount(1));
+        assertEquals("999", CountFormatter.formatCount(999));
+    }
+
+    @Test
+    void testThousands() {
+        assertEquals("1K", CountFormatter.formatCount(1000));
+        assertEquals("1.5K", CountFormatter.formatCount(1500));
+        assertEquals("9.9K", CountFormatter.formatCount(9999));
+        assertEquals("10K", CountFormatter.formatCount(10_000));
+        assertEquals("100K", CountFormatter.formatCount(100_000));
+        assertEquals("999K", CountFormatter.formatCount(999_999));
+    }
+
+    @Test
+    void testMillions() {
+        assertEquals("1M", CountFormatter.formatCount(1_000_000));
+        assertEquals("2.8M", CountFormatter.formatCount(2_800_000));
+        assertEquals("9.9M", CountFormatter.formatCount(9_999_999));
+        assertEquals("10M", CountFormatter.formatCount(10_000_000));
+        assertEquals("999M", CountFormatter.formatCount(999_999_999));
+    }
+
+    @Test
+    void testBillions() {
+        assertEquals("1B", CountFormatter.formatCount(1_000_000_000));
+        assertEquals("1.2B", CountFormatter.formatCount(1_200_000_000));
+        assertEquals("9.9B", CountFormatter.formatCount(9_999_999_999L));
+        assertEquals("10B", CountFormatter.formatCount(10_000_000_000L));
+        assertEquals("100B", CountFormatter.formatCount(100_000_000_000L));
+    }
+
+    @Test
+    void testDecimalDropsTrailingZero() {
+        assertEquals("1K", CountFormatter.formatCount(1000));
+        assertEquals("2K", CountFormatter.formatCount(2000));
+        assertEquals("1M", CountFormatter.formatCount(1_000_000));
+        assertEquals("5M", CountFormatter.formatCount(5_000_000));
+        assertEquals("1B", CountFormatter.formatCount(1_000_000_000));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `CountFormatter` utility with decimal-precision formatting (e.g. 1.5K, 2.8M, 1.2B) for counts under 10x each threshold
- Apply `formatCount()` to the header capacity display, replacing comma-formatted numbers (e.g. "2.8M/10M" instead of "2,800,000/10,240,000")
- Add `FormatCountTest` covering boundary cases, decimal values, and trailing-zero dropping

Closes #29

## Test plan
- [x] `./gradlew :core:test` — FormatCountTest passes
- [x] `./gradlew :neoforge:compileJava` — compiles clean
- [ ] Game tests pass in CI
- [ ] Visual: header shows abbreviated counts in-game