### PR TITLE
Show exact item count on hover with Shift

### DIFF
--- a/core/src/main/java/io/github/scuba10steve/s3/util/CountFormatter.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/util/CountFormatter.java
@@ -14,6 +14,10 @@ public final class CountFormatter {
         return (count / 1_000_000_000) + "B";
     }
 
+    public static String formatExactCount(long count) {
+        return String.format("%,d", count);
+    }
+
     private static String formatWithSuffix(long count, long divisor, String suffix) {
         long whole = count / divisor;
         long fraction = (count % divisor) * 10 / divisor;

--- a/core/src/test/java/io/github/scuba10steve/s3/util/CountFormatterTest.java
+++ b/core/src/test/java/io/github/scuba10steve/s3/util/CountFormatterTest.java
@@ -1,0 +1,37 @@
+package io.github.scuba10steve.s3.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CountFormatterTest {
+
+    @Test
+    void testFormatExactCountSmallValues() {
+        assertEquals("0", CountFormatter.formatExactCount(0));
+        assertEquals("1", CountFormatter.formatExactCount(1));
+        assertEquals("999", CountFormatter.formatExactCount(999));
+    }
+
+    @Test
+    void testFormatExactCountWithCommaGrouping() {
+        assertEquals("1,000", CountFormatter.formatExactCount(1000));
+        assertEquals("1,234", CountFormatter.formatExactCount(1234));
+        assertEquals("10,000", CountFormatter.formatExactCount(10_000));
+        assertEquals("999,999", CountFormatter.formatExactCount(999_999));
+    }
+
+    @Test
+    void testFormatExactCountMillions() {
+        assertEquals("1,000,000", CountFormatter.formatExactCount(1_000_000));
+        assertEquals("1,234,567", CountFormatter.formatExactCount(1_234_567));
+        assertEquals("999,999,999", CountFormatter.formatExactCount(999_999_999));
+    }
+
+    @Test
+    void testFormatExactCountBillions() {
+        assertEquals("1,000,000,000", CountFormatter.formatExactCount(1_000_000_000));
+        assertEquals("10,000,000,000", CountFormatter.formatExactCount(10_000_000_000L));
+        assertEquals("100,000,000,000", CountFormatter.formatExactCount(100_000_000_000L));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CountFormatter.formatExactCount()` for comma-formatted counts
- Holding Shift in the storage GUI switches count overlays from truncated (1.2K) to exact (1,234)
- Holding Shift while hovering shows "Stored: X" with the exact count in the tooltip
- Header capacity display also toggles between truncated and exact format

Closes #35

## Test plan
- [x] Open storage core GUI with items stored
- [x] Verify count overlays show truncated format (1.2K, 3.4M) normally
- [x] Hold Shift — overlays switch to comma-formatted exact counts
- [x] Hold Shift while hovering over an item — tooltip shows "Stored: X" line
- [x] Release Shift — display reverts to truncated format
- [x] `./gradlew :core:test` passes (includes new `CountFormatterTest`)