### PR TITLE
Add on-demand OpenRewrite workflow (#47)

### DIFF
--- a/.github/workflows/openrewrite.yml
+++ b/.github/workflows/openrewrite.yml
@@ -1,0 +1,82 @@
+name: OpenRewrite
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Preview changes without committing (uploads diff as artifact)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  rewrite:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run OpenRewrite recipes
+        run: ./gradlew rewriteRun
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload diff artifact (dry run)
+        if: inputs.dry_run && steps.changes.outputs.has_changes == 'true'
+        run: git diff > openrewrite-changes.patch
+      - name: Upload diff
+        if: inputs.dry_run && steps.changes.outputs.has_changes == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: openrewrite-diff
+          path: openrewrite-changes.patch
+
+      - name: Create branch and open PR
+        if: ${{ !inputs.dry_run && steps.changes.outputs.has_changes == 'true' }}
+        run: |
+          set -e
+          branch="openrewrite/run-$(date -u +%Y%m%d-%H%M%S)"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add -A
+          git commit -m "Apply OpenRewrite recipes"
+          git push -u origin "$branch"
+
+          changed_files=$(git diff --name-only HEAD~1)
+          body=$(printf "## Summary\nApplied OpenRewrite recipes from \`build.gradle\` configuration.\n\n### Changed files\n\`\`\`\n%s\n\`\`\`" "$changed_files")
+
+          gh pr create \
+            --title "Apply OpenRewrite recipes" \
+            --body "$body" \
+            --base main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: No changes detected
+        if: steps.changes.outputs.has_changes == 'false'
+        run: echo "No changes detected — all code already conforms to active recipes."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@ The primary purpose of an AI agent in this repository is to assist human develop
 *   **Dry-run first** when unsure of impact: `./gradlew rewriteDryRun` previews changes without modifying files.
 *   **Discover available recipes** with `./gradlew rewriteDiscover`.
 *   Only handle manually what OpenRewrite recipes cannot cover.
+*   **On-demand workflow:** Trigger `gh workflow run openrewrite.yml` to run recipes in CI and auto-open a PR. Use `-f dry_run=true` to preview changes as a downloadable artifact without committing.
 
 ## Issue Creation
 


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` workflow to run OpenRewrite recipes on demand
- Supports dry-run mode (uploads diff as artifact) and auto-PR mode (creates branch, commits, opens PR)
- Update AGENTS.md with workflow usage documentation

## Usage
- `gh workflow run openrewrite.yml` — run recipes and auto-open a PR
- `gh workflow run openrewrite.yml -f dry_run=true` — preview changes as downloadable artifact

## Test plan
- [x] YAML validates with pyyaml
- [x] Workflow follows existing CI/bump-version patterns
- [ ] Manual trigger from Actions tab to verify end-to-end

Closes #47