### PR TITLE
Add optional Polymorph compatibility for crafting recipe conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,5 +43,9 @@ subprojects {
             name = 'Jared'
             url = 'https://maven.blamejared.com'
         }
+        maven {
+            name = 'Modrinth'
+            url = 'https://api.modrinth.com/maven'
+        }
     }
 }

--- a/core/src/main/java/io/github/scuba10steve/s3/gui/server/StorageCoreCraftingMenu.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/gui/server/StorageCoreCraftingMenu.java
@@ -9,9 +9,9 @@ import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.*;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.CraftingInput;
 import net.minecraft.world.item.crafting.CraftingRecipe;
 import net.minecraft.world.item.crafting.RecipeHolder;
-import net.minecraft.world.item.crafting.RecipeType;
 
 import java.util.List;
 import java.util.Optional;
@@ -57,13 +57,14 @@ public class StorageCoreCraftingMenu extends StorageCoreMenu {
             ServerPlayer serverPlayer = (ServerPlayer) player;
             ItemStack itemstack = ItemStack.EMPTY;
 
-            Optional<RecipeHolder<CraftingRecipe>> optional = player.level().getServer().getRecipeManager().getRecipeFor(
-                    RecipeType.CRAFTING, ((CraftingContainer) craftMatrix).asCraftInput(), player.level());
+            CraftingInput craftInput = ((CraftingContainer) craftMatrix).asCraftInput();
+            Optional<RecipeHolder<CraftingRecipe>> optional = S3Platform.findCraftingRecipe(
+                    this, craftInput, player.level(), player);
 
             if (optional.isPresent()) {
                 RecipeHolder<CraftingRecipe> recipe = optional.get();
                 if (craftResult.setRecipeUsed(player.level(), serverPlayer, recipe)) {
-                    itemstack = recipe.value().assemble(((CraftingContainer) craftMatrix).asCraftInput(), player.level().registryAccess());
+                    itemstack = recipe.value().assemble(craftInput, player.level().registryAccess());
                 }
             }
 

--- a/core/src/main/java/io/github/scuba10steve/s3/platform/S3Platform.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/platform/S3Platform.java
@@ -3,10 +3,18 @@ package io.github.scuba10steve.s3.platform;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.item.Item;
+import net.minecraft.world.item.crafting.CraftingInput;
+import net.minecraft.world.item.crafting.CraftingRecipe;
+import net.minecraft.world.item.crafting.RecipeHolder;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -115,6 +123,29 @@ public final class S3Platform {
 
     public static void setNetworkHelper(S3NetworkHelper helper) {
         networkHelper = helper;
+    }
+
+    // --- Crafting Recipe Lookup ---
+    @FunctionalInterface
+    public interface CraftingRecipeLookup {
+        Optional<RecipeHolder<CraftingRecipe>> find(
+                AbstractContainerMenu menu,
+                CraftingInput input,
+                Level level,
+                Player player);
+    }
+
+    private static CraftingRecipeLookup craftingRecipeLookup =
+            (menu, input, level, player) ->
+                    level.getServer().getRecipeManager().getRecipeFor(RecipeType.CRAFTING, input, level);
+
+    public static Optional<RecipeHolder<CraftingRecipe>> findCraftingRecipe(
+            AbstractContainerMenu menu, CraftingInput input, Level level, Player player) {
+        return craftingRecipeLookup.find(menu, input, level, player);
+    }
+
+    public static void setCraftingRecipeLookup(CraftingRecipeLookup lookup) {
+        craftingRecipeLookup = lookup;
     }
 
     // --- Menu Opener ---

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -47,6 +47,9 @@ dependencies {
     compileOnly "mezz.jei:jei-1.21.1-neoforge-api:19.27.0.340"
     runtimeOnly "mezz.jei:jei-1.21.1-neoforge:19.27.0.340"
 
+    // Polymorph integration (optional at runtime)
+    compileOnly "maven.modrinth:polymorph:1.1.0+1.21.1"
+
     // Test dependencies
     testImplementation 'org.junit.jupiter:junit-jupiter:5.14.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/neoforge/src/main/java/io/github/scuba10steve/s3/StevesSimpleStorage.java
+++ b/neoforge/src/main/java/io/github/scuba10steve/s3/StevesSimpleStorage.java
@@ -1,5 +1,6 @@
 package io.github.scuba10steve.s3;
 
+import io.github.scuba10steve.s3.compat.PolymorphCompat;
 import io.github.scuba10steve.s3.config.StorageClientConfig;
 import io.github.scuba10steve.s3.config.StorageConfig;
 import io.github.scuba10steve.s3.init.*;
@@ -11,6 +12,7 @@ import io.github.scuba10steve.s3.ref.RefStrings;
 import io.github.scuba10steve.s3.util.StorageUtils;
 import net.neoforged.bus.api.IEventBus;
 import net.neoforged.fml.ModContainer;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.Mod;
 import net.neoforged.fml.config.ModConfig;
 import net.neoforged.fml.event.lifecycle.FMLCommonSetupEvent;
@@ -60,6 +62,10 @@ public class StevesSimpleStorage {
 
 		S3Platform.setKeyItem(ModItems.KEY::get);
 		S3Platform.setMenuOpener((player, provider, pos) -> player.openMenu(provider, pos));
+
+		if (ModList.get().isLoaded("polymorph")) {
+			PolymorphCompat.register();
+		}
 
 		modEventBus.addListener(this::commonSetup);
 		modContainer.registerConfig(ModConfig.Type.COMMON, StorageConfig.SPEC);

--- a/neoforge/src/main/java/io/github/scuba10steve/s3/client/ClientEvents.java
+++ b/neoforge/src/main/java/io/github/scuba10steve/s3/client/ClientEvents.java
@@ -1,5 +1,6 @@
 package io.github.scuba10steve.s3.client;
 
+import io.github.scuba10steve.s3.compat.PolymorphCompat;
 import io.github.scuba10steve.s3.gui.client.ExtractPortScreen;
 import io.github.scuba10steve.s3.gui.client.SecurityBoxScreen;
 import io.github.scuba10steve.s3.gui.client.StatisticsBoxScreen;
@@ -16,6 +17,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.component.CustomData;
 import net.neoforged.api.distmarker.Dist;
 import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.ModList;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.fml.common.EventBusSubscriber.Bus;
 import net.neoforged.fml.event.lifecycle.FMLClientSetupEvent;
@@ -39,6 +41,10 @@ public class ClientEvents {
             ResourceLocation dollyState = ResourceLocation.fromNamespaceAndPath(RefStrings.MODID, "dolly_state");
             registerDollyProperty(ModItems.DOLLY.get(), dollyState);
             registerDollyProperty(ModItems.DOLLY_SUPER.get(), dollyState);
+
+            if (ModList.get().isLoaded("polymorph")) {
+                PolymorphCompat.registerClientWidget();
+            }
         });
     }
 

--- a/neoforge/src/main/java/io/github/scuba10steve/s3/compat/PolymorphCompat.java
+++ b/neoforge/src/main/java/io/github/scuba10steve/s3/compat/PolymorphCompat.java
@@ -1,0 +1,49 @@
+package io.github.scuba10steve.s3.compat;
+
+import com.illusivesoulworks.polymorph.api.PolymorphApi;
+import com.illusivesoulworks.polymorph.api.client.PolymorphWidgets;
+import com.illusivesoulworks.polymorph.api.client.widgets.PlayerRecipesWidget;
+import io.github.scuba10steve.s3.gui.client.StorageCoreCraftingScreen;
+import io.github.scuba10steve.s3.platform.S3Platform;
+import net.minecraft.world.inventory.Slot;
+import net.minecraft.world.item.crafting.RecipeType;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+/**
+ * Optional compatibility with Polymorph, which resolves recipe conflicts when multiple mods
+ * register recipes with the same crafting pattern. Without this integration, S3's crafting box
+ * would always use whichever recipe the RecipeManager returns first, ignoring the player's choice.
+ *
+ * Registered only when Polymorph is loaded (mod id: "polymorph").
+ */
+public class PolymorphCompat {
+
+    /**
+     * Overrides S3's recipe lookup to delegate to Polymorph's player-recipe selection,
+     * so that the recipe the player picked in Polymorph's UI is the one that gets crafted.
+     */
+    public static void register() {
+        S3Platform.setCraftingRecipeLookup((menu, input, level, player) ->
+                PolymorphApi.getInstance().getRecipeManager()
+                        .getPlayerRecipe(menu, RecipeType.CRAFTING, input, level, player));
+    }
+
+    /**
+     * Registers a Polymorph widget factory for S3's crafting screen so the conflict-selection
+     * button appears when multiple recipes match the current crafting grid.
+     */
+    @OnlyIn(Dist.CLIENT)
+    public static void registerClientWidget() {
+        PolymorphWidgets.getInstance().registerWidget(screen -> {
+            if (!(screen instanceof StorageCoreCraftingScreen)) {
+                return null;
+            }
+            Slot resultSlot = PolymorphWidgets.getInstance().findResultSlot(screen);
+            if (resultSlot == null) {
+                return null;
+            }
+            return new PlayerRecipesWidget(screen, resultSlot);
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an optional integration with [Polymorph](https://modrinth.com/mod/polymorph) so S3's crafting box respects the player's recipe selection when multiple mods register conflicting crafting patterns.
- Introduces a `CraftingRecipeLookup` strategy in `S3Platform` (defaults to vanilla behavior) that NeoForge overrides at startup when Polymorph is detected, delegating to `IPolymorphRecipeManager.getPlayerRecipe()`.
- Registers a `PolymorphWidgets` factory on the client so Polymorph's conflict-selection button appears on S3's crafting screen.
- Integration is fully opt-in: S3 behaves identically without Polymorph installed.

Closes #59

## Test Plan

- [ ] Without Polymorph: crafting box works normally, no regressions
- [ ] With Polymorph installed and a recipe conflict present: Polymorph's disambiguation button appears on the S3 crafting screen
- [ ] Selecting a recipe in Polymorph's UI causes the correct result to appear in the crafting output slot
- [ ] JEI recipe transfer still works correctly with and without Polymorph