### PR TITLE
fix: skip empty ItemStacks during save and sync (#69)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ docs/superpowers/
 # Moderne CLI
 .moderne/*
 !.moderne/context/
+
+# AI Assistants/tools
+.claude/
+.kiro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,64 @@ Before working on any area of the codebase, read the relevant doc in `docs/`:
 | Troubleshooting common issues | [docs/troubleshooting.md](docs/troubleshooting.md) |
 | 1.0.0 release status | [docs/v1.0.0-release.md](docs/v1.0.0-release.md) |
 
+## Project Structure
+
+```text
+core/                 Platform-agnostic code (vanilla MC classes via neoFormVersion)
+  src/main/java/io/github/scuba10steve/s3/
+    block/            Block classes and multiblock components
+    blockentity/      Block entity implementations (core storage logic)
+    gui/              Shared menu/screen logic and UI helpers
+    platform/         Platform abstraction interfaces and helpers
+  src/main/resources/
+    assets/s3/lang/   Localization files (en_us.json is the reference)
+    data/s3/          Recipes, tags, loot tables, advancements
+
+neoforge/s3/          NeoForge-specific runtime module
+  src/main/java/io/github/scuba10steve/s3/
+    init/             DeferredRegister holders (blocks, items, entities, menus)
+    client/           Client-only screen/event registration
+    config/           NeoForge config bridge
+    network/          Packet registration and handlers
+    jei/              JEI integration classes
+
+gametest/s3/          NeoForge GameTest module and data generation entry points
+
+docs/                 Technical docs (architecture, integrations, troubleshooting)
+scripts/              Local dev helpers (server, copy jar, fetch logs)
+```
+
+## Build And Verification Commands
+
+```bash
+# Build all modules
+./gradlew build
+
+# Build key modules directly
+./gradlew :core:build :neoforge:s3:build :gametest:s3:build
+
+# Unit tests + checks (includes core:validateLang through check)
+./gradlew test check
+
+# Run NeoForge GameTests (full game test server startup)
+./gradlew :gametest:s3:runGameTestServer
+
+# Local manual test helpers
+bash scripts/server.sh
+bash scripts/copy.sh
+bash scripts/get_logs.sh
+```
+
+**After code changes, run at least `./gradlew :neoforge:s3:build` before claiming completion.**
+
+## Key Codebase Conventions
+
+- **Multi-module boundaries:** Keep cross-platform logic in `core`; keep NeoForge-only APIs and registrations in `neoforge/s3`.
+- **Platform abstraction:** Prefer existing abstraction points (`S3Platform`, config/network helpers) instead of introducing direct loader coupling into `core`.
+- **Localization parity:** `core/src/main/resources/assets/s3/lang/en_us.json` is the key-set source of truth; `validateLang` enforces parity for other locales.
+- **Registration flow:** New blocks/items/entities/menus should follow existing DeferredRegister patterns in `neoforge/s3/src/main/java/io/github/scuba10steve/s3/init/`.
+- **Automation and integration:** Changes touching storage transfer, recipes, or UI interactions should account for JEI integration and GameTest coverage where applicable.
+
 ## Core Mandates
 
 1.  **Adherence to Conventions:** Always prioritize and rigorously adhere to existing project conventions (code style, naming, architecture, documentation) when reading or modifying code. Analyze surrounding code, tests, and configuration files (e.g., `package.json`, `Cargo.toml`, `requirements.txt`, `build.gradle`) to understand established patterns.

--- a/core/src/main/java/io/github/scuba10steve/s3/network/StorageSyncPacket.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/network/StorageSyncPacket.java
@@ -71,8 +71,9 @@ public record StorageSyncPacket(
     }
 
     private static void writeItems(RegistryFriendlyByteBuf buf, List<StoredItemStack> items) {
-        buf.writeInt(items.size());
-        for (StoredItemStack item : items) {
+        List<StoredItemStack> valid = items.stream().filter(i -> !i.getItemStack().isEmpty()).toList();
+        buf.writeInt(valid.size());
+        for (StoredItemStack item : valid) {
             ItemStack.STREAM_CODEC.encode(buf, item.getItemStack());
             buf.writeLong(item.getCount());
         }

--- a/core/src/main/java/io/github/scuba10steve/s3/storage/StorageInventory.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/storage/StorageInventory.java
@@ -177,7 +177,8 @@ public class StorageInventory {
 
         ListTag itemsList = new ListTag();
         for (StoredItemStack stored : items.values()) {
-            itemsList.add(stored.save(registries));
+            CompoundTag itemTag = stored.save(registries);
+            if (itemTag != null) itemsList.add(itemTag);
         }
         tag.put("Items", itemsList);
 
@@ -193,6 +194,7 @@ public class StorageInventory {
         for (int i = 0; i < itemsList.size(); i++) {
             CompoundTag itemTag = itemsList.getCompound(i);
             StoredItemStack stored = StoredItemStack.load(itemTag, registries);
+            if (stored.getItemStack().isEmpty()) continue; // skip items from removed/updated mods
             items.put(new ItemKey(stored.getItemStack()), stored);
             totalCount += stored.getCount();
         }

--- a/core/src/main/java/io/github/scuba10steve/s3/storage/StoredItemStack.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/storage/StoredItemStack.java
@@ -34,6 +34,7 @@ public class StoredItemStack {
     }
     
     public CompoundTag save(HolderLookup.Provider registries) {
+        if (itemStack.isEmpty()) return null;
         CompoundTag tag = new CompoundTag();
         tag.put("Item", itemStack.save(registries));
         tag.putLong("Count", count);

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This directory contains comprehensive technical documentation for Steve's Simple
 - **[Configuration](configuration.md)** - TOML configuration system and options
 - **[Build System](build-system.md)** - Multi-module Gradle configuration and build process
 - **[Dependencies](dependencies.md)** - Dependency versions and update tracking
+- **[Integrations](integrations.md)** - Current mod integrations and future options
 - **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
 - **[v1.0.0 Release Plan](v1.0.0-release.md)** - Tracking items for the first stable release
 - **[Changelog](../CHANGELOG.md)** - Version history and changes

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -1,0 +1,192 @@
+# Integrations
+
+This document tracks integration status for Steve's Simple Storage (S3): what is already implemented, what is generic interoperability, and what integrations are good candidates next.
+
+## Field Notes (ATM10)
+
+Current real-world testing context from active pack usage:
+- Target modpack context: **All The Mods 10 (ATM10)**
+- **Mekanism compatibility**: mostly working based on in-pack playtesting
+- **Functional Storage**: not directly tested yet
+- **Tom's Simple Storage**: currently low priority (not in ATM10 and not a familiar target)
+
+How this affects priorities:
+- Move item-logistics validation from "unknown" to "stabilize and document"
+- Keep Functional Storage as a concrete validation target
+- De-emphasize Tom's Simple Storage unless user demand appears
+
+## Current Integrations
+
+### JEI (Just Enough Items) - Implemented
+
+Status: **Implemented and enabled by default**
+
+What is currently integrated:
+- Recipe transfer from JEI into S3 crafting menus
+- Ingredient lookup (R/U workflow) from S3 storage GUI entries
+- Runtime bridge so S3 can open JEI recipe UI from S3 screens
+
+Where it is wired:
+- `neoforge/s3/src/main/java/io/github/scuba10steve/s3/jei/StorageJEIPlugin.java`
+- `neoforge/s3/src/main/java/io/github/scuba10steve/s3/jei/StorageRecipeTransferHandler.java`
+- `neoforge/s3/src/main/java/io/github/scuba10steve/s3/jei/StorageGuiContainerHandler.java`
+- `neoforge/s3/src/main/java/io/github/scuba10steve/s3/jei/JEIIntegration.java`
+
+Configuration:
+- `integration.jeiIntegration` in `config/s3-common.toml`
+
+Dependency type:
+- `runtimeOnly` in `neoforge/s3/build.gradle`
+
+---
+
+### Polymorph - Implemented (Optional)
+
+Status: **Implemented, loaded only when present**
+
+What is currently integrated:
+- Crafting recipe conflict resolution in S3 crafting context
+- Client-side Polymorph recipe-selection widget on S3 crafting screen
+
+Where it is wired:
+- Runtime detection and registration in `neoforge/s3/src/main/java/io/github/scuba10steve/s3/StevesSimpleStorage.java`
+- Client widget registration in `neoforge/s3/src/main/java/io/github/scuba10steve/s3/client/ClientEvents.java`
+- Compatibility adapter in `neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PolymorphCompat.java`
+
+Dependency type:
+- `compileOnly` in `neoforge/s3/build.gradle` with `ModList.get().isLoaded("polymorph")` guards
+
+---
+
+### Generic Item Automation / Cross-Mod Interop - Implemented
+
+Status: **Implemented as generic NeoForge capability interoperability**
+
+What is currently integrated:
+- `Capabilities.ItemHandler.BLOCK` exposure for:
+  - Input Port
+  - Extract Port
+  - Storage Interface
+- Allows hopper/pipe/item-network mods to insert/extract through standard item handler APIs
+
+Where it is wired:
+- Capability registration: `neoforge/s3/src/main/java/io/github/scuba10steve/s3/init/ModCapabilities.java`
+- Storage Interface handler: `neoforge/s3/src/main/java/io/github/scuba10steve/s3/blockentity/StorageInterfaceBlockEntity.java`
+
+Notes:
+- This is not a single hard dependency on another mod; it is baseline compatibility with any mod using NeoForge item handler capabilities.
+
+## Integration Gaps / Candidates
+
+The following options are listed in rough priority order, balancing user impact and implementation complexity.
+
+### High-Value Near-Term
+
+1. **EMI support**
+   - Why: growing adoption as a JEI alternative; similar player expectations around recipe transfer/lookup
+   - Scope: plugin + transfer handlers + GUI interaction hooks (parallel to JEI architecture)
+
+2. **REI support (if NeoForge support target is stable enough)**
+   - Why: additional recipe viewer ecosystem coverage
+   - Scope: equivalent to JEI/EMI feature parity for transfer and lookup
+
+3. **Jade / The One Probe overlays**
+   - Why: quick visibility into storage stats and multiblock state without opening GUI
+   - Scope: provider overlays showing item count, capacity, lock status, and linked core details
+
+### Medium-Term
+
+4. **CraftTweaker / KubeJS recipe scripting hooks**
+   - Why: modpack creators want recipe and progression control
+   - Scope: expose S3 recipes/components in script APIs; document supported script operations
+
+5. **Curios integration (if wearable/wireless features expand)**
+   - Why: enables wearable terminal/key use cases for QoL and progression
+   - Scope: optional item slot behavior for S3 utility items
+
+### Longer-Term / Feature-Dependent
+
+6. **Applied Energistics 2 / Refined Storage bridge**
+   - Why: major ecosystem interoperability request for late-game packs
+   - Scope: likely requires deliberate design boundary to avoid replacing either system's identity
+
+7. **CC: Tweaked automation API**
+   - Why: programmable access appeals to technical automation players
+   - Scope: peripheral or API surface for querying and moving items
+
+8. **Energy and fluid ecosystem integrations**
+   - Why: aligns with planned advanced-storage direction (power/fluid components)
+   - Scope: expose and consume FE/fluid capabilities when those systems are introduced
+
+## Additional Candidate Options
+
+These are extra options worth considering after the core roadmap above.
+
+### Storage and Inventory Ecosystem
+
+9. **Tom's Simple Storage compatibility layer**
+   - Why: conceptually similar user base; useful for migration packs and side-by-side systems
+   - Scope: import/export adapter recipes or bridge block behavior where feasible
+   - Priority note: currently lower priority for ATM10-focused work
+
+10. **Sophisticated Backpacks / Sophisticated Storage**
+   - Why: common in modpacks; players expect portable storage workflows to connect smoothly
+   - Scope: recipe lookup and item transfer UX tuning, plus optional whitelist/blacklist rules
+
+11. **Functional Storage**
+   - Why: high pack adoption; drawer-style bulk storage complements S3 core storage
+   - Scope: documented capability interoperability and optional QoL hooks for bulk transfers
+
+### Automation and Item Logistics
+
+12. **Pipez / Mekanism logistical transport / modular pipes**
+   - Why: broad automation mod usage; users care about predictable extraction/insertion behavior
+   - Scope: compatibility validation matrix + side-aware behavior docs for ports/interfaces
+   - Current status note: Mekanism appears mostly compatible in ATM10; next step is formal validation/documentation
+
+13. **Create logistics adjacency support**
+   - Why: Create-heavy packs are common and benefit from smooth mechanical automation interop
+   - Scope: test and document belt/funnel/chute interactions with S3 ports and interface
+
+### Information and UI Integrations
+
+14. **Catalogue / Configured / Mod Menu equivalents (where available)**
+   - Why: easier in-game configuration discoverability
+   - Scope: config screen entry points and category descriptions for S3 settings
+
+15. **FTB Quests / Better Questing helper integration**
+   - Why: improves pack onboarding; storage progression is often quest-driven
+   - Scope: documented detection hooks and optional helper tags for quest objectives
+
+### Server and Tooling Integrations
+
+16. **Spark profiling playbook integration**
+   - Why: large storage systems can become performance-sensitive on servers
+   - Scope: ship recommended profiling commands and S3-specific interpretation guidance
+
+17. **Server utility mods (e.g., chunk loaders / claim mods) compatibility notes**
+   - Why: common source of "it works in singleplayer but not server" reports
+   - Scope: known-behavior matrix for chunk-loading, permissions, and automation edge cases
+
+## Selection Heuristics
+
+To choose what to build first:
+- Prefer integrations that improve **core crafting and retrieval UX** (recipe viewers, overlays)
+- Next prioritize integrations that reduce **modpack support friction** (automation compatibility docs)
+- Defer deep bridges (AE2/RS-level) until there is a clear **design boundary** and maintenance budget
+
+## Suggested Next Steps
+
+If choosing one immediate target for **new** integration work, **EMI** is likely the highest-impact next integration after JEI/Polymorph.
+
+Recommended rollout:
+1. Add `docs` design note for shared recipe-viewer abstraction (JEI already exists; avoid duplicated logic)
+2. Implement minimal viewer parity (lookup + transfer)
+3. Add manual verification checklist in `TESTING.md` for cross-viewer behavior
+4. Optional: add gametest or integration smoke hooks where feasible
+
+## Immediate Validation Backlog (ATM10-Oriented)
+
+1. Verify and document Mekanism edge cases (sided IO, extraction pacing, redstone disable behavior)
+2. Run direct compatibility pass for Functional Storage (drawer insert/extract behavior through S3 interfaces)
+3. Add a short "Known Working in ATM10" section once the above is confirmed


### PR DESCRIPTION
## Summary

Fixes #69 — storage appearing empty after a modpack update.

After a pack update, items from removed or updated mods resolve to `ItemStack.EMPTY`. This caused two failures:
- `IllegalStateException: Cannot encode empty ItemStack` in `StorageCoreBlockEntity.saveAdditional` → block entity fails to persist, contents lost on next load
- `EncoderException: Empty ItemStack not allowed` in `StorageSyncPacket` → player disconnected immediately on join

## Changes

- **`StoredItemStack.save`** — returns `null` if item is empty
- **`StorageInventory.save`** — skips `null` entries
- **`StorageInventory.load`** — skips entries where item resolved to empty (unresolvable registry key)
- **`StorageSyncPacket.writeItems`** — filters empty stacks before encoding

Items from missing/updated mods are now silently dropped rather than crashing the save and wiping all storage contents.