### PR TITLE
feat: add in-game Patchouli guidebook (issue #76)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           changelog: ${{ steps.changelog.outputs.content }}
           dependencies: |
             jei@19.27.0.336(optional){modrinth:jei}
+            patchouli(optional){modrinth:patchouli}
 
       - name: Publish to CurseForge
         uses: Kir-Antipov/mc-publish@v3.3
@@ -104,6 +105,7 @@ jobs:
           changelog: ${{ steps.changelog.outputs.content }}
           dependencies: |
             jei@19.27.0.336(optional){curseforge:238222}
+            patchouli(optional){curseforge:306770}
 
       # TODO: Enable once Nexus Mods Upload API access is granted
       # - name: Publish to Nexus Mods

--- a/neoforge/s3/build.gradle
+++ b/neoforge/s3/build.gradle
@@ -37,6 +37,8 @@ processResources {
 dependencies {
     runtimeOnly "mezz.jei:jei-1.21.1-neoforge:19.27.0.340"
     compileOnly "maven.modrinth:polymorph:1.1.0+1.21.1"
+    compileOnly "vazkii.patchouli:Patchouli:1.21.1-93-NEOFORGE:api"
+    runtimeOnly "vazkii.patchouli:Patchouli:1.21.1-93-NEOFORGE"
     coreClasses project(path: ':core', configuration: 'coreOutput')
 }
 

--- a/neoforge/s3/src/main/java/io/github/scuba10steve/s3/StevesSimpleStorage.java
+++ b/neoforge/s3/src/main/java/io/github/scuba10steve/s3/StevesSimpleStorage.java
@@ -1,5 +1,6 @@
 package io.github.scuba10steve.s3;
 
+import io.github.scuba10steve.s3.compat.PatchouliCompat;
 import io.github.scuba10steve.s3.compat.PolymorphCompat;
 import io.github.scuba10steve.s3.config.StorageClientConfig;
 import io.github.scuba10steve.s3.config.StorageConfig;
@@ -65,6 +66,10 @@ public class StevesSimpleStorage {
 
 		if (ModList.get().isLoaded("polymorph")) {
 			PolymorphCompat.register();
+		}
+
+		if (ModList.get().isLoaded("patchouli")) {
+			PatchouliCompat.register();
 		}
 
 		modEventBus.addListener(this::commonSetup);

--- a/neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PatchouliCompat.java
+++ b/neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PatchouliCompat.java
@@ -33,7 +33,7 @@ public class PatchouliCompat {
         }
 
         player.addItem(PatchouliAPI.get().getBookStack(GUIDEBOOK_ID));
-        player.sendSystemMessage(Component.literal("scuba10steve has left you a gift! You should check your inventory..."));
+        player.sendSystemMessage(Component.literal("Simple Steve has left you a gift! You should check your inventory..."));
         player.getPersistentData().putBoolean(GIFT_RECEIVED_KEY, true);
     }
 }

--- a/neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PatchouliCompat.java
+++ b/neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PatchouliCompat.java
@@ -33,7 +33,7 @@ public class PatchouliCompat {
         }
 
         player.addItem(PatchouliAPI.get().getBookStack(GUIDEBOOK_ID));
-        player.sendSystemMessage(Component.literal("Simple Steve has left you a gift! You should check your inventory..."));
+        player.sendSystemMessage(Component.literal("scuba10steve has left you a gift! You should check your inventory..."));
         player.getPersistentData().putBoolean(GIFT_RECEIVED_KEY, true);
     }
 }

--- a/neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PatchouliCompat.java
+++ b/neoforge/s3/src/main/java/io/github/scuba10steve/s3/compat/PatchouliCompat.java
@@ -1,0 +1,39 @@
+package io.github.scuba10steve.s3.compat;
+
+import io.github.scuba10steve.s3.ref.RefStrings;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.player.PlayerEvent;
+import vazkii.patchouli.api.PatchouliAPI;
+
+/**
+ * Optional compatibility with Patchouli. Gifts the S3 guidebook to each player the first time
+ * they log in while Patchouli is loaded.
+ *
+ * Registered only when Patchouli is loaded (mod id: "patchouli").
+ */
+public class PatchouliCompat {
+
+    private static final String GIFT_RECEIVED_KEY = "s3_received_guidebook";
+    private static final ResourceLocation GUIDEBOOK_ID = ResourceLocation.fromNamespaceAndPath(RefStrings.MODID, "guidebook");
+
+    public static void register() {
+        NeoForge.EVENT_BUS.addListener(PatchouliCompat::onPlayerLogin);
+    }
+
+    private static void onPlayerLogin(PlayerEvent.PlayerLoggedInEvent event) {
+        Player player = event.getEntity();
+        if (player.level().isClientSide()) {
+            return;
+        }
+        if (player.getPersistentData().getBoolean(GIFT_RECEIVED_KEY)) {
+            return;
+        }
+
+        player.addItem(PatchouliAPI.get().getBookStack(GUIDEBOOK_ID));
+        player.sendSystemMessage(Component.literal("Simple Steve has left you a gift! You should check your inventory..."));
+        player.getPersistentData().putBoolean(GIFT_RECEIVED_KEY, true);
+    }
+}

--- a/neoforge/s3/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/s3/src/main/resources/META-INF/neoforge.mods.toml
@@ -22,3 +22,10 @@ type="required"
 versionRange="[1.21.1,1.22)"
 ordering="NONE"
 side="BOTH"
+
+[[dependencies.s3]]
+modId="patchouli"
+type="optional"
+versionRange="*"
+ordering="NONE"
+side="BOTH"

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/getting_started.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/getting_started.json
@@ -1,0 +1,6 @@
+{
+  "name": "Getting Started",
+  "description": "Learn how to build and configure your first storage system.",
+  "icon": "s3:storage_core",
+  "sortnum": 0
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/ports.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/ports.json
@@ -1,0 +1,6 @@
+{
+  "name": "Port Blocks",
+  "description": "Automate item flow into and out of your storage system.",
+  "icon": "s3:input_port",
+  "sortnum": 2
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/storage_blocks.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/storage_blocks.json
@@ -1,0 +1,6 @@
+{
+  "name": "Storage Blocks",
+  "description": "Storage cores, boxes, and their capacities across all tiers.",
+  "icon": "s3:storage_box",
+  "sortnum": 1
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/utility.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/categories/utility.json
@@ -1,0 +1,6 @@
+{
+  "name": "Utility Blocks",
+  "description": "Enhance your storage with search, sorting, crafting, security, and more.",
+  "icon": "s3:search_box",
+  "sortnum": 3
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/getting_started/first_storage.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/getting_started/first_storage.json
@@ -1,0 +1,26 @@
+{
+  "name": "Building Your First Storage",
+  "category": "s3:getting_started",
+  "icon": "s3:storage_box",
+  "sortnum": 1,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:storage_core",
+      "text": "The $(item)Storage Core$() is the heart of your system. Place it first."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach $(item)Storage Boxes$() to any face of the Core or chain them together in a connected multiblock. All connected boxes share their capacity with the Core.$(br2)Open the Core's GUI to view, search, and manage everything stored inside."
+    },
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:input_port",
+      "text": "Add an $(item)Input Port$() to automate item insertion."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Place an $(item)Input Port$() on any face of the multiblock to pull items in from adjacent inventories or hoppers. Use an $(item)Extract Port$() or $(item)Eject Port$() to move items out. See $(bold)Port Blocks$() for details."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/getting_started/welcome.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/getting_started/welcome.json
@@ -1,0 +1,16 @@
+{
+  "name": "Introduction",
+  "category": "s3:getting_started",
+  "icon": "s3:storage_core",
+  "sortnum": 0,
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "$(bold)Steve's Simple Storage$() is a mass storage mod that lets you centralize your items in a single, easy-to-use system.$(br2)Use the categories in this guide to learn about every block in the mod."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "$(bold)Categories:$()$(br)$(item)Getting Started$() — build your first system$(br)$(item)Storage Blocks$() — cores and boxes$(br)$(item)Port Blocks$() — automate item flow$(br)$(item)Utility Blocks$() — search, sort, craft, and more"
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/ports/eject_port.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/ports/eject_port.json
@@ -1,0 +1,17 @@
+{
+  "name": "Eject Port",
+  "category": "s3:ports",
+  "icon": "s3:eject_port",
+  "sortnum": 2,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:eject_port",
+      "text": "Pushes items out of storage into an adjacent inventory."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The $(item)Eject Port$() continuously outputs items from the storage system into an adjacent inventory or hopper. Unlike the $(item)Extract Port$(), it does not use a filter — it ejects items as space is available in the target inventory."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/ports/extract_port.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/ports/extract_port.json
@@ -1,0 +1,17 @@
+{
+  "name": "Extract Port",
+  "category": "s3:ports",
+  "icon": "s3:extract_port",
+  "sortnum": 1,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:extract_port",
+      "text": "Pulls specific items out of storage into an adjacent inventory."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The $(item)Extract Port$() lets you specify which items to pull from the storage system. Open its GUI to configure a filter. It will only extract items matching the filter and push them into the adjacent inventory."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/ports/input_port.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/ports/input_port.json
@@ -1,0 +1,17 @@
+{
+  "name": "Input Port",
+  "category": "s3:ports",
+  "icon": "s3:input_port",
+  "sortnum": 0,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:input_port",
+      "text": "Pulls items from adjacent inventories into storage."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Place an $(item)Input Port$() on any face of your storage multiblock. It will automatically pull items from any inventory (chest, hopper, machine output) placed against its open face and insert them into the $(item)Storage Core$()."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/storage_blocks/storage_core.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/storage_blocks/storage_core.json
@@ -1,0 +1,21 @@
+{
+  "name": "Storage Core",
+  "category": "s3:storage_blocks",
+  "icon": "s3:storage_core",
+  "sortnum": 0,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:storage_core",
+      "text": "The controller for your entire storage system."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The $(item)Storage Core$() manages all items in the connected multiblock. Open it to access your inventory with a 6×9 grid of storage slots.$(br2)The GUI also displays your current item count and total capacity."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach utility blocks such as the $(item)Search Box$(), $(item)Sort Box$(), and $(item)Crafting Box$() to add extra functionality to the GUI. Only one of each utility block can be active per Core."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/storage_blocks/storage_tiers.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/storage_blocks/storage_tiers.json
@@ -1,0 +1,20 @@
+{
+  "name": "Storage Boxes",
+  "category": "s3:storage_blocks",
+  "icon": "s3:storage_box",
+  "sortnum": 1,
+  "pages": [
+    {
+      "type": "patchouli:text",
+      "text": "$(item)Storage Boxes$() expand the capacity of your system. Connect them to the $(item)Storage Core$() or chain them together — all connected boxes contribute their capacity to the shared pool."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "$(bold)Tiers and capacities:$()$(br)$(item)Basic$() — 10,000 items$(br)$(item)Condensed$() — 40,000 items$(br)$(item)Compressed$() — 80,000 items$(br)$(item)Super$() — 160,000 items$(br)$(item)Ultra$() — 640,000 items$(br)$(item)Hyper$() — 2,560,000 items$(br)$(item)Ultimate$() — 10,240,000 items"
+    },
+    {
+      "type": "patchouli:text",
+      "text": "You can mix and match tiers freely. Use the $(item)Dolly$() or $(item)Super Dolly$() to move placed boxes without losing their contents."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/access_terminal.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/access_terminal.json
@@ -1,0 +1,17 @@
+{
+  "name": "Access Terminal",
+  "category": "s3:utility",
+  "icon": "s3:access_terminal",
+  "sortnum": 5,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:access_terminal",
+      "text": "A remote access point for the storage GUI."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "The $(item)Access Terminal$() must be connected to your multiblock. Once placed, you can open the full $(item)Storage Core$() GUI from the terminal instead of the core itself — useful when the core is buried or hard to reach."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/crafting_box.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/crafting_box.json
@@ -1,0 +1,17 @@
+{
+  "name": "Crafting Box",
+  "category": "s3:utility",
+  "icon": "s3:crafting_box",
+  "sortnum": 2,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:crafting_box",
+      "text": "Adds a 3×3 crafting grid to the Storage Core GUI."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach the $(item)Crafting Box$() to your multiblock to embed a full crafting grid directly in the $(item)Storage Core$() GUI. Craft items without opening a separate crafting table — the output goes straight into your inventory. Only one Crafting Box per Core."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/dolly.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/dolly.json
@@ -1,0 +1,17 @@
+{
+  "name": "Dollies",
+  "category": "s3:utility",
+  "icon": "s3:dolly",
+  "sortnum": 7,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:dolly",
+      "text": "Move storage blocks without losing their contents."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Use a $(item)Dolly$() to pick up and relocate $(item)Storage Boxes$() and other blocks while keeping their contents intact. The $(item)Super Dolly$() can carry heavier or larger blocks. Right-click a block to pick it up, then right-click a surface to place it."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/search_box.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/search_box.json
@@ -1,0 +1,17 @@
+{
+  "name": "Search Box",
+  "category": "s3:utility",
+  "icon": "s3:search_box",
+  "sortnum": 0,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:search_box",
+      "text": "Adds a search bar to the Storage Core GUI."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach the $(item)Search Box$() to your multiblock to add a text search field to the $(item)Storage Core$() GUI. Type any part of an item name to filter the displayed contents. Only one Search Box can be active per Core."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/security_box.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/security_box.json
@@ -1,0 +1,17 @@
+{
+  "name": "Security Box",
+  "category": "s3:utility",
+  "icon": "s3:security_box",
+  "sortnum": 3,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:security_box",
+      "text": "Restricts access to the storage system using keys."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach the $(item)Security Box$() and insert a $(item)Key$() to lock the storage system. Only players holding a matching Key can open the $(item)Storage Core$() GUI. Useful for shared servers or keeping your items private."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/sort_box.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/sort_box.json
@@ -1,0 +1,17 @@
+{
+  "name": "Sort Box",
+  "category": "s3:utility",
+  "icon": "s3:sort_box",
+  "sortnum": 1,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:sort_box",
+      "text": "Adds sorting controls to the Storage Core GUI."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach the $(item)Sort Box$() to your multiblock to add sorting buttons to the $(item)Storage Core$() GUI. Choose from 6 sort modes: by name (A–Z / Z–A), by quantity (most/least first), or by mod. Only one Sort Box can be active per Core."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/statistics_box.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/statistics_box.json
@@ -1,0 +1,17 @@
+{
+  "name": "Statistics Box",
+  "category": "s3:utility",
+  "icon": "s3:statistics_box",
+  "sortnum": 4,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:statistics_box",
+      "text": "Displays item counts and capacity usage."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach the $(item)Statistics Box$() to your multiblock to add a capacity readout to the $(item)Storage Core$() GUI. See your total item count, unique item types, and how full your storage is at a glance."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/storage_interface.json
+++ b/neoforge/s3/src/main/resources/assets/s3/patchouli_books/guidebook/en_us/entries/utility/storage_interface.json
@@ -1,0 +1,17 @@
+{
+  "name": "Storage Interface",
+  "category": "s3:utility",
+  "icon": "s3:storage_interface",
+  "sortnum": 6,
+  "pages": [
+    {
+      "type": "patchouli:spotlight",
+      "item": "s3:storage_interface",
+      "text": "Exposes storage as a standard inventory to adjacent machines."
+    },
+    {
+      "type": "patchouli:text",
+      "text": "Attach the $(item)Storage Interface$() to your multiblock. Machines, hoppers, and other blocks adjacent to it will see the storage system as a normal inventory, allowing them to insert and extract items without special integration."
+    }
+  ]
+}

--- a/neoforge/s3/src/main/resources/data/s3/patchouli_books/guidebook/book.json
+++ b/neoforge/s3/src/main/resources/data/s3/patchouli_books/guidebook/book.json
@@ -1,0 +1,8 @@
+{
+  "name": "Steve's Simple Storage Guide",
+  "landing_text": "Welcome to Steve's Simple Storage! Use this guide to learn how to build and configure your storage system.",
+  "version": 1,
+  "creative_tab": "s3:s3",
+  "use_resource_pack": true,
+  "model": "patchouli:book_blue"
+}

--- a/neoforge/s3/src/main/resources/data/s3/recipes/guidebook.json
+++ b/neoforge/s3/src/main/resources/data/s3/recipes/guidebook.json
@@ -1,0 +1,13 @@
+{
+  "type": "minecraft:crafting_shapeless",
+  "ingredients": [
+    {"item": "minecraft:book"},
+    {"item": "s3:storage_core"}
+  ],
+  "result": {
+    "id": "patchouli:guide_book",
+    "components": {
+      "patchouli:book": "s3:guidebook"
+    }
+  }
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+./gradlew :neoforge:s3:build "$@"


### PR DESCRIPTION
## Summary
- Adds Patchouli 1.21.1-93-NEOFORGE as a compileOnly/runtimeOnly dependency
- Creates a full Patchouli guidebook covering all 4 categories: Getting Started, Storage Blocks, Port Blocks, and Utility Blocks (15 entries total)
- Adds a shapeless crafting recipe (`book + storage_core → guidebook`) for survival players

## Test plan
- Obtain the guidebook from the S3 creative tab or craft it (`book + storage_core`)
- Open the book and verify the landing page, all 4 categories, and all entries render correctly
- Confirm no missing texture errors on item spotlight pages
- Verify the crafting recipe works in survival