### PR TITLE
fix: keep storage menu open when player is far from core

### DIFF
--- a/core/src/main/java/io/github/scuba10steve/s3/gui/server/StorageCoreMenu.java
+++ b/core/src/main/java/io/github/scuba10steve/s3/gui/server/StorageCoreMenu.java
@@ -107,7 +107,11 @@ public class StorageCoreMenu extends AbstractContainerMenu {
 
     @Override
     public boolean stillValid(Player player) {
-        return blockEntity != null &&
-                player.distanceToSqr(pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5) <= 64;
+        // No distance check: the menu may be opened from an Access Terminal arbitrarily
+        // far from the Storage Core, so tying validity to the core's position would close
+        // the screen on the first server tick whenever the terminal is more than 8 blocks
+        // from the core. The player must be in reach of either the core or a terminal to
+        // open the menu in the first place.
+        return blockEntity != null;
     }
 }

--- a/gametest/s3/src/main/java/io/github/scuba10steve/s3/gametest/StorageGameTests.java
+++ b/gametest/s3/src/main/java/io/github/scuba10steve/s3/gametest/StorageGameTests.java
@@ -2,6 +2,7 @@ package io.github.scuba10steve.s3.gametest;
 
 import io.github.scuba10steve.s3.blockentity.StorageCoreBlockEntity;
 import io.github.scuba10steve.s3.gui.server.StorageCoreCraftingMenu;
+import io.github.scuba10steve.s3.gui.server.StorageCoreMenu;
 import io.github.scuba10steve.s3.init.ModBlocks;
 import io.github.scuba10steve.s3.storage.StorageInventory;
 import io.github.scuba10steve.s3.storage.StoredItemStack;
@@ -451,6 +452,33 @@ public class StorageGameTests {
             long expectedCount = countBefore + 3; // 3 items placed in grid
             if (countAfter != expectedCount) {
                 helper.fail("Expected " + expectedCount + " items in storage after grid clear, got " + countAfter);
+                return;
+            }
+
+            helper.succeed();
+        });
+    }
+
+    /**
+     * Regression test: the Access Terminal opens the storage menu with the core's BlockPos,
+     * so {@code stillValid} must not close the screen when the player is far from the core.
+     * Previously, the menu's distance check rejected any player more than 8 blocks from the
+     * core, causing the screen to flash open and immediately close — defeating the whole
+     * purpose of the Access Terminal.
+     */
+    @GameTest(template = "core_with_storage_box", setupTicks = 5)
+    public static void storage_menu_stays_valid_when_player_far_from_core(GameTestHelper helper) {
+        helper.runAfterDelay(5, () -> {
+            BlockPos absPos = helper.absolutePos(CORE_POS);
+            ServerPlayer mockPlayer = helper.makeMockServerPlayerInLevel();
+            StorageCoreMenu menu = new StorageCoreMenu(0, mockPlayer.getInventory(), absPos);
+
+            // Move the player ~50 blocks from the core — well beyond the old 8-block check
+            mockPlayer.teleportTo(absPos.getX() + 50.0, absPos.getY(), absPos.getZ());
+
+            if (!menu.stillValid(mockPlayer)) {
+                helper.fail("stillValid returned false for player 50 blocks from core; "
+                    + "Access Terminal would close immediately");
                 return;
             }
 


### PR DESCRIPTION
## Summary

Fixes a CurseForge-reported bug where the Access Terminal screen "flashes for a moment but then just exits out again."

`StorageCoreMenu.stillValid` measured the player's distance to the menu's `pos`, which is **always the storage core's position** (see `BlockAccessTerminal.useWithoutItem` — it opens the menu with `core.getBlockPos()`). When the player was more than 8 blocks (`√64`) from the core — the entire point of using an Access Terminal — `stillValid` returned `false` on the first server tick and the menu closed immediately.

Drop the distance check. The player must be in reach of either the core or a terminal to right-click and open the menu in the first place, so the distance check provides no real protection but reliably breaks the Access Terminal use case. This matches how AE2 terminals and Refined Storage grids behave.

## Test plan
- [x] `./gradlew :core:compileJava :gametest:s3:compileJava` succeeds
- [x] `./gradlew :core:test` passes
- [x] Added gametest `storage_menu_stays_valid_when_player_far_from_core` that constructs a `StorageCoreMenu`, teleports a mock player 50 blocks away, and asserts `stillValid` returns true — regression coverage for this bug
- [ ] Manual: place a Storage Core, run a chain of storage blocks ~20 blocks out to an Access Terminal, right-click the terminal, confirm the GUI stays open